### PR TITLE
Bugfix in function "mqttWriteString"

### DIFF
--- a/MQTT_Sending.scl
+++ b/MQTT_Sending.scl
@@ -104,7 +104,7 @@ BEGIN
 	#i := 0;
 	
 	FOR #j := 1 TO BYTE_TO_INT(#_str.act_length) DO
-	    "mqttData".buffer[#newPos] := #_str.str[#j];
+	    "mqttData".buffer[#newPos] := #_str.str[#j - 1];
 	    #newPos := #newPos + 1;
 	    #i := #i + 1;
 	END_FOR;


### PR DESCRIPTION
Issue: The chars of the message where displaced by one position, because the String Array #_str.str is zero based.
Solution: The index #j in line 107 must be subtracted by one.